### PR TITLE
Add a function to get from cache or execute

### DIFF
--- a/packages/runtime/src/getSSRComputation.tsx
+++ b/packages/runtime/src/getSSRComputation.tsx
@@ -1,0 +1,19 @@
+import { calculateCacheKey, Dependency, parseDependencies } from "./utils";
+
+export default function getSSRComputation(importFn: () => Promise<{ default: (...dependencies: Dependency[]) => any }>, dependencies: any, relativePathToCwd: string) {
+  const cache = window.__SSR_CACHE__;
+  const parsedDependencies = parseDependencies(dependencies);
+
+  // relativePathToCwd is used to make sure that the cache key is unique for each module
+  // and it's not affected by the file that calls it
+  const cacheKey = calculateCacheKey(relativePathToCwd, parsedDependencies);
+  const isCacheHit = cache?.[cacheKey];
+
+  if (isCacheHit) {
+    return Promise.resolve(cache[cacheKey]);
+  }
+
+  return importFn().then((module) => {
+    return module.default(...parsedDependencies);
+  });
+}

--- a/packages/runtime/src/index.runtime.ts
+++ b/packages/runtime/src/index.runtime.ts
@@ -1,1 +1,2 @@
 export { SSRCacheProvider } from './SSRCacheProvider';
+export { default as getSSRComputation } from './getSSRComputation';

--- a/packages/runtime/src/useSSRComputation_Client.tsx
+++ b/packages/runtime/src/useSSRComputation_Client.tsx
@@ -1,17 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSSRCache } from "./SSRCacheProvider";
-import { calculateCacheKey, Dependency, isDependency } from "./utils";
+import { calculateCacheKey, Dependency, parseDependencies } from "./utils";
 
 export default function useSSRComputation_Client(importFn: () => Promise<{ default: (...dependencies: Dependency[]) => any }>, dependencies: any[], relativePathToCwd: string) {
   const [fn, setFn] = useState<(...dependencies: Dependency[])=>any>();
   const cache = useSSRCache();
-
-  const parsedDependencies = dependencies.map((dependency) => {
-    if (isDependency(dependency)) {
-      return dependency;
-    }
-    throw new Error(`useSSRComputation: dependency ${dependency} is not a valid dependency object`);
-  }) as Dependency[];
+  const parsedDependencies = parseDependencies(dependencies);
 
   // relativePathToCwd is used to make sure that the cache key is unique for each module
   // and it's not affected by the file that calls it

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -4,6 +4,19 @@ export function isDependency(element: any): element is Dependency {
   return typeof element === 'number' || typeof element === 'string' || (typeof element === 'object' && element.uniqueId !== undefined);
 }
 
+export function parseDependencies(dependencies: any): Dependency[] {
+  if (!Array.isArray(dependencies)) {
+    throw new Error('Dependencies must be an array.');
+  }
+
+  return dependencies.map((dependency) => {
+    if (isDependency(dependency)) {
+      return dependency;
+    }
+    throw new Error(`useSSRComputation: dependency ${dependency} is not a valid dependency object`);
+  });
+}
+
 export const calculateCacheKey = (modulePath: string, dependencies: Dependency[]): string => {
   const dependenciesString = dependencies.map((dependency) => {
     if (typeof dependency === 'number') {


### PR DESCRIPTION
Adds the function `getSSRCalculation` that can be used outside React components. It looks for the cached value in the cache. If the value is found, it's returned. Otherwise, it downloads the file, executes it, and returns the value.