### PR TITLE
Add the ability to ignore caching server-side result

### DIFF
--- a/packages/runtime/src/index.runtime.ts
+++ b/packages/runtime/src/index.runtime.ts
@@ -1,2 +1,3 @@
 export { SSRCacheProvider } from './SSRCacheProvider';
 export { default as getSSRComputation } from './getSSRComputation';
+export { ignoreCache } from './utils';

--- a/packages/runtime/src/useSSRComputation_Server.tsx
+++ b/packages/runtime/src/useSSRComputation_Server.tsx
@@ -1,5 +1,6 @@
 import { useSSRCache } from "./SSRCacheProvider";
 import { calculateCacheKey } from "./utils";
+import { IgnoreCache } from './utils';
 
 export default function useSSRComputation_Server(fn: (...dependencies: any[]) => any, dependencies: any[], relativePathToCwd: string) {
   const cache = useSSRCache();
@@ -9,12 +10,13 @@ export default function useSSRComputation_Server(fn: (...dependencies: any[]) =>
     // relativePathToCwd is used to make sure that the cache key is unique for each module
     // and it's not affected by the file that calls it
     const cacheKey = calculateCacheKey(relativePathToCwd, dependencies);
-    // check if result is a promise
-    if (result && typeof result.then === 'function') {
-      cache[cacheKey] = result.then(asyncResult => cache[cacheKey] = asyncResult);
-    } else {
-      cache[cacheKey] = result;
+
+    // check if it should ignore caching
+    if (result && result[IgnoreCache]) {
+      return result.result;
     }
+
+    cache[cacheKey] = result;
   }
 
   return result;

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -30,3 +30,12 @@ export const calculateCacheKey = (modulePath: string, dependencies: Dependency[]
 
   return `${modulePath}::${dependenciesString}`;
 }
+
+export const IgnoreCache = Symbol('IgnoreCache');
+
+export const ignoreCache = (result: any) => {
+  return {
+    [IgnoreCache]: true,
+    result,
+  };
+}


### PR DESCRIPTION
It adds the ability to ignore caching the value returned from the server-side. It can be used if the server-side result is not ready, so the client will need to recalculate it

## Example

> import { ignoreCache } from 'use-ssr-computation.runtime';
> function fetchUsers() {
>
>>   if (UsersStore.cached) return { loading: false, users: UsersStore.all };
>>  return ignoreCache({ loading: true, users: UsersStore.fetchAll() });
>
> }