### PR TITLE
Implement continuous deployment on GitHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
         run: yarn install --frozen-lockfile
+      - name: find changes
+        run: lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fetch tags
-        run: git fetch --tags origin
+        run: git fetch --prune --unshallow
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
         run: yarn install --frozen-lockfile
+      - name: Ensure that "lerna version" has been run
+        run: |
+          changed=$(yarn run changed || echo "")
+          if [ -n "$changed" ]; then
+            echo "Error: Found changed packages. Please run 'lerna version' before pushing changes." >&2
+            exit 1
+          fi
       - name: Publish package on NPM 📦
         run: yarn run lerna publish from-package --yes --dist-tag experimental
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Ensure that "lerna version" has been run
         run: |
-          changed=$(yarn run changed || echo "")
+          changed=$(yarn run --silent changed)
           if [ -n "$changed" ]; then
-            echo "Error: Found changed packages. Please run 'lerna version' before pushing changes." >&2
+            echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
             exit 1
           fi
       - name: Publish package on NPM 📦

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: find changes
-        run: lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - abanoubghadban/sc-65675/implement-continous-deployment-on-github
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,10 +22,10 @@ jobs:
         run: |
           changed=$(yarn run --silent changed || true)
           if [ -n "$changed" ]; then
-            echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
+            echo "Error: Found changed packages. Please run 'yarn run version'. Also, make sure to push the tags wih `git push --tags origin`." >&2
             exit 1
           fi
       - name: Publish package on NPM 📦
-        run: yarn run publish --dist-tag experimental
+        run: yarn run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,13 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies 🔧
         run: yarn install --frozen-lockfile
+      - name: unpublish packages
+        run: |
+          npm unpublish @popmenu/use-ssr-computation.macro@1.2.2
+          npm unpublish @popmenu/use-ssr-computation.runtime@1.1.3
+          exit 1
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed || true)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Fetch tags
+        run: git fetch --tags origin
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish to NPM
+on:
+  push:
+    branches:
+      - master
+      - abanoubghadban/sc-65675/implement-continous-deployment-on-github
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies and build 🔧
+        run: yarn install --frozen-lockfile
+      - name: Publish package on NPM 📦
+        run: yarn run lerna publish from-package --yes --dist-tag experimental
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Ensure that "lerna version" has been run
         run: |
-          changed=$(yarn run --silent changed)
+          changed=$(yarn run --silent changed || true)
           if [ -n "$changed" ]; then
             echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install dependencies and build 🔧
-        run: yarn install --frozen-lockfile
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed)
@@ -26,6 +24,8 @@ jobs:
             echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
             exit 1
           fi
+      - name: Install dependencies and build 🔧
+        run: yarn install --frozen-lockfile
       - name: Publish package on NPM 📦
         run: yarn run lerna publish from-package --yes --dist-tag experimental
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,9 @@ jobs:
             echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
             exit 1
           fi
-      - name: Install dependencies and build 🔧
+      - name: Install dependencies 🔧
         run: yarn install --frozen-lockfile
       - name: Publish package on NPM 📦
-        run: yarn run lerna publish from-package --yes --dist-tag experimental
+        run: yarn run publish --dist-tag experimental
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies 🔧
         run: yarn install --frozen-lockfile
-      - name: unpublish packages
-        run: |
-          npm unpublish @popmenu/use-ssr-computation.macro@1.2.2
-          npm unpublish @popmenu/use-ssr-computation.runtime@1.1.3
-          exit 1
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed || true)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies 🔧
+        run: yarn install --frozen-lockfile
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed || true)
@@ -24,8 +26,6 @@ jobs:
             echo "Error: Found changed packages. Please run 'yarn run version' before pushing changes." >&2
             exit 1
           fi
-      - name: Install dependencies 🔧
-        run: yarn install --frozen-lockfile
       - name: Publish package on NPM 📦
         run: yarn run publish --dist-tag experimental
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: find changes
+        run: lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
         run: yarn install --frozen-lockfile
-      - name: find changes
-        run: lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'
       - name: Ensure that "lerna version" has been run
         run: |
           changed=$(yarn run --silent changed)

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "version": "independent",
+  "npmClient": "yarn"
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "publish": "lerna publish",
     "changed": "lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
+    "version": "lerna version --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
     "yalc": "cd packages/macro && yalc publish && cd ../runtime && yalc publish",
     "test": "cd packages/macro && yarn test && cd ../runtime && yarn test"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "license": "MIT",
   "scripts": {
-    "publish": "lerna publish",
+    "publish": "lerna publish from-package --yes",
     "changed": "lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
     "version": "lerna version --no-push --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
     "yalc": "cd packages/macro && yalc publish && cd ../runtime && yalc publish",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "publish": "lerna publish",
     "changed": "lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
-    "version": "lerna version --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
+    "version": "lerna version --no-push --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
     "yalc": "cd packages/macro && yalc publish && cd ../runtime && yalc publish",
     "test": "cd packages/macro && yarn test && cd ../runtime && yarn test"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "publish": "lerna publish",
+    "changed": "lerna changed --ignore-changes '**/*.md' '**/test/*' '**/__snapshots__/*' '**/*.test.{ts,tsx,js,jsx}'",
     "yalc": "cd packages/macro && yalc publish && cd ../runtime && yalc publish",
     "test": "cd packages/macro && yarn test && cd ../runtime && yarn test"
   },

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.macro",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "lib/index.macro.js",
   "types": "lib/index.macro.d.ts",
   "license": "MIT",
@@ -26,7 +26,7 @@
   },
   "author": "Roman Kuksin <rkuksin.cpp@gmail.com>",
   "dependencies": {
-    "@popmenu/use-ssr-computation.runtime": "^1.1.1",
+    "@popmenu/use-ssr-computation.runtime": "^1.1.3",
     "babel-plugin-macros": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.macro",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "main": "lib/index.macro.js",
   "types": "lib/index.macro.d.ts",
   "license": "MIT",
@@ -26,7 +26,7 @@
   },
   "author": "Roman Kuksin <rkuksin.cpp@gmail.com>",
   "dependencies": {
-    "@popmenu/use-ssr-computation.runtime": "^1.1.3",
+    "@popmenu/use-ssr-computation.runtime": "^1.1.1",
     "babel-plugin-macros": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.macro",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "lib/index.macro.js",
   "types": "lib/index.macro.d.ts",
   "license": "MIT",
@@ -26,8 +26,8 @@
   },
   "author": "Roman Kuksin <rkuksin.cpp@gmail.com>",
   "dependencies": {
-    "babel-plugin-macros": "^3.0.0",
-    "@popmenu/use-ssr-computation.runtime": "*"
+    "@popmenu/use-ssr-computation.runtime": "^1.1.1",
+    "babel-plugin-macros": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/macro/package.json
+++ b/packages/macro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.macro",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "main": "lib/index.macro.js",
   "types": "lib/index.macro.d.ts",
   "license": "MIT",
@@ -26,7 +26,7 @@
   },
   "author": "Roman Kuksin <rkuksin.cpp@gmail.com>",
   "dependencies": {
-    "@popmenu/use-ssr-computation.runtime": "^1.1.1",
+    "@popmenu/use-ssr-computation.runtime": "^1.1.5",
     "babel-plugin-macros": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@popmenu/use-ssr-computation.runtime",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "main": "lib/index.runtime.js",
   "types": "lib/index.runtime.d.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
The PR implements the `continuous deployment` of the macro on GitHub.

**The macro is published to npm when any new PR is merged into the master under the following conditions**:
- It publishes the package(s) that their `version` is/are changed. If neither the `runtime` nor `macro` package is altered in the version, nothing will be published.
- The version numbers should not be changed manually. Instead, use the command `yarn run version` to update the package version with any changes.
- **Make sure to commit all changes before calling `yarn run version`**.
- **Make sure to push the branch tags like `git push --tags origin**

Already used to publish some `experimental` versions like here
https://github.com/Popmenu/use-ssr-computation.macro/actions/runs/6297666971/job/17095138588